### PR TITLE
Added emergency backstop in startup assembly

### DIFF
--- a/possum_os/src/start.s
+++ b/possum_os/src/start.s
@@ -7,6 +7,9 @@ _start:
     ldr     x30, =LD_STACK_PTR
     mov     sp, x30
     bl      _rust_start
+_backstop: // Emergency wfi loop in case main returns
+    wfi
+    b       _backstop
 
 .equ PSCI_SYSTEM_OFF, 0x84000008
 .globl system_off


### PR DESCRIPTION
Added backup infinite loop after the branching call to `_rust_start` just in case main somehow returns.